### PR TITLE
Add explain and single commit options

### DIFF
--- a/src/CommitFinder.cs
+++ b/src/CommitFinder.cs
@@ -33,7 +33,6 @@ namespace clio
 
 		public static Option<CommitInfo> ParseSingle (string path, string hash)
 		{
-
 			try
 			{
 				using (var repo = new Repository (path))

--- a/src/CommitParser.cs
+++ b/src/CommitParser.cs
@@ -50,19 +50,30 @@ namespace clio
 					int id;
 					if (int.TryParse (match.Groups[match.Groups.Count - 1].Value, out id))
 					{
+						if (options.Explain)
+							Console.WriteLine ($"\tLine \"{line}\" matched pattern {regex}.");
+
 						if (options.IgnoreLowBugs && id < 1000)
 							return new ParseResults { Confidence = ParsingConfidence.Invalid };
+
+						if (options.Explain)
+							Console.WriteLine ($"\tHad a valid id {id}.");
 
 						ParsingConfidence confidence = ParsingConfidence.High;
 
 						if (line.Contains ("Context") || line.Contains ("context"))
 							confidence = ParsingConfidence.Low;
 
+						if (options.Explain)
+							Console.WriteLine ($"\tDefault Confidence was {confidence}.");
+
 						string bugzillaSummary = GetTitle (id);
 						if (bugzillaSummary == null)
 						{
 							confidence = ParsingConfidence.Low;
 							bugzillaSummary = "";
+							if (options.Explain)
+								Console.WriteLine ($"\tGiven low confidence due to lack of a matching bugzilla bug.");
 						}
 
 						return new ParseResults() { Confidence = confidence, Link = match.Value, ID = id, BugzillaSummary = bugzillaSummary };
@@ -74,6 +85,9 @@ namespace clio
 
 		public static Option<ParsedCommit> ParseSingle (CommitInfo commit, SearchOptions options)
 		{
+			if (options.Explain)
+				Console.WriteLine ($"Analyzing {commit.Hash}.");
+
 			var textToSearch = commit.Description.SplitLines ();
 			var topMatch = textToSearch.Select (x => ParseLine (x, options)).OrderBy (x => x.Confidence).FirstOrDefault ();
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -27,9 +27,11 @@ namespace clio
 				{ "o|output=", "Path to output release notes (Defaults to current directory)", o => output = o },
 				{ "s|starting=", "Starting to consider", s => options.Starting = s.Some () },
 				{ "e|ending=", "Ending to consider", e => options.Ending = e.Some () },
-				{ "exclude-starting-item", "Exclude starting items from range considered (included by default)", v => options.IncludeStarting = false },
 
+				{ "single=", "Analyze just a single commit", e => options.SingleCommit = e.Some () },
+				{ "exclude-starting-item", "Exclude starting items from range considered (included by default)", v => options.IncludeStarting = false },
 				{ "ignore-low-bugs=", "Ignore any bug references to bugs with IDs less than 1000 (Defaults to true)", (bool v) => options.IgnoreLowBugs = v },
+				{ "explain", "Explain why each commit is considered a bug", v => options.Explain = true },
 			};
 
 			try 

--- a/src/SearchOptions.cs
+++ b/src/SearchOptions.cs
@@ -6,11 +6,14 @@ namespace clio
 	public class SearchOptions
 	{
 		public bool IgnoreLowBugs { get; set; } = true;
+		public bool OnlyListCommitsConsidered { get; set; } = false;
+		public bool Explain { get; set; } = false;
+		public Option<string> SingleCommit { get; set; } = Option.None<string> ();
 
 		public Option<string> Starting { get; set; } = Option.None<string> ();
 		public bool IncludeStarting { get; set; } = true;
 		public Option<string> Ending { get; set; } = Option.None<string> ();
 
-		public bool OnlyListCommitsConsidered = false;
+
 	}
 }

--- a/src/TODO.md
+++ b/src/TODO.md
@@ -1,4 +1,6 @@
-﻿- From built in template generate links
+﻿- Handle branches instead of hashes (walk up to commit parent?)
+
+- From built in template generate links
 - External templates instead of built in?
 
 - Look at something for feature PRs?

--- a/src/clio.cs
+++ b/src/clio.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using clio.Model;
 using Optional;
 
 namespace clio
@@ -23,11 +25,25 @@ namespace clio
 
 		public void Run ()
 		{
-			var commits = CommitFinder.Parse (Path, Options);
+			IEnumerable<CommitInfo> commits = null;
+
+			Options.SingleCommit.Match (single => {
+				commits = CommitFinder.ParseSingle (Path, single).Match (x => x.Yield (), () => Enumerable.Empty<CommitInfo> ());
+			}, () => { 
+				commits = CommitFinder.Parse (Path, Options);
+			});
+
+			if (Options.Explain)
+				Console.WriteLine ($"Found {commits.Count ()} commits.");
+
 			if (Options.OnlyListCommitsConsidered)
 			{
 				foreach (var commit in commits)
 					Console.WriteLine ($"{commit.Hash} {commit.Title}");
+
+				if (Options.Explain)
+					Console.WriteLine ($"Only listing of commits was requested. Exiting.");
+
 				return;
 			}
 


### PR DESCRIPTION
- I confused myself with the -l option enough that it felt like a good time to add a --explain