### PR TITLE
Quality of Life Fixes

### DIFF
--- a/src/BugzillaChecker.cs
+++ b/src/BugzillaChecker.cs
@@ -32,7 +32,7 @@ namespace clio
 					return new ValueTuple<string, string> (loginText[0], loginText[1]);
 			}
 
-			throw new InvalidOperationException ("Unable to determine bugzilla login infomration. Please set BUGZILLA_LOGIN/BUGZILLA_PASSWORD environmental variable or create ~/.bugzilla with two lines");
+			throw new InvalidOperationException ("Unable to determine bugzilla login infomration. Please set BUGZILLA_LOGIN/BUGZILLA_PASSWORD environmental variable, create ~/.bugzilla with two lines, or pass --disable-bugzilla");
 		}
 
 		public async Task Setup ()

--- a/src/CommitFinder.cs
+++ b/src/CommitFinder.cs
@@ -63,7 +63,7 @@ namespace clio
 				Commit newestCommit = repo.Lookup<Commit> (newest);
 				if (newestCommit == null)
 				{
-					Console.Error.WriteLine ($"Unable to find ending hash {oldest} in repo.");
+					Console.Error.WriteLine ($"Unable to find ending hash {newest} in repo.");
 					return false;
 				}
 

--- a/src/CommitFinder.cs
+++ b/src/CommitFinder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using clio.Model;
 using LibGit2Sharp;
@@ -10,13 +11,13 @@ namespace clio
 	{
 		public static IEnumerable<CommitInfo> Parse (string path, SearchOptions options)
 		{
-			try 
+			try
 			{
-				using (var repo = new Repository (path)) 
+				using (var repo = new Repository (path))
 				{
 					var filter = new CommitFilter ();
-					options.Starting.MatchSome (v => filter.ExcludeReachableFrom = v + (options.IncludeStarting ? "~" : ""));
-					options.Ending.MatchSome (v => filter.IncludeReachableFrom = v);
+					options.Oldest.MatchSome (v => filter.ExcludeReachableFrom = v + (options.IncludeOldest ? "~" : ""));
+					options.Newest.MatchSome (v => filter.IncludeReachableFrom = v);
 
 					return repo.Commits.QueryBy (filter).Select (x => new CommitInfo (x.Sha, x.MessageShort, x.Message)).ToList ();
 				}
@@ -46,6 +47,39 @@ namespace clio
 			catch (RepositoryNotFoundException)
 			{
 				return Option.None<CommitInfo> ();
+			}
+		}
+
+		public static bool ValidateGitHashes (string path, string oldest, string newest)
+		{
+			using (var repo = new Repository (path))
+			{
+				Commit oldestCommit = repo.Lookup<Commit> (oldest);
+				if (oldestCommit == null)
+				{
+					Console.Error.WriteLine ($"Unable to find starting hash {oldest} in repo.");
+					return false;
+				}
+				Commit newestCommit = repo.Lookup<Commit> (newest);
+				if (newestCommit == null)
+				{
+					Console.Error.WriteLine ($"Unable to find ending hash {oldest} in repo.");
+					return false;
+				}
+
+				var filter = new CommitFilter
+				{
+					ExcludeReachableFrom = oldest,
+					IncludeReachableFrom = newest
+				};
+
+				if (!repo.Commits.QueryBy (filter).Any ())
+				{
+					Console.Error.WriteLine ($"Unable to find any commit in range {oldest} to {newest}. Is the order reversed?");
+					return false;
+				}
+
+				return true;
 			}
 		}
 	}

--- a/src/CommitParser.cs
+++ b/src/CommitParser.cs
@@ -67,13 +67,17 @@ namespace clio
 						if (options.Explain)
 							Console.WriteLine ($"\tDefault Confidence was {confidence}.");
 
-						string bugzillaSummary = GetTitle (id);
-						if (bugzillaSummary == null)
+						string bugzillaSummary = "";
+						if (!options.DisableBugzillaValidation)
 						{
-							confidence = ParsingConfidence.Low;
-							bugzillaSummary = "";
-							if (options.Explain)
-								Console.WriteLine ($"\tGiven low confidence due to lack of a matching bugzilla bug.");
+							bugzillaSummary = GetTitle (id);
+							if (bugzillaSummary == null)
+							{
+								confidence = ParsingConfidence.Low;
+								bugzillaSummary = "";
+								if (options.Explain)
+									Console.WriteLine ($"\tGiven low confidence due to lack of a matching bugzilla bug.");
+							}
 						}
 
 						return new ParseResults() { Confidence = confidence, Link = match.Value, ID = id, BugzillaSummary = bugzillaSummary };

--- a/src/EntryPoint.cs
+++ b/src/EntryPoint.cs
@@ -44,6 +44,7 @@ namespace clio
 				{ "exclude-oldest", "Exclude oldest item from range considered (included by default)", v => options.IncludeOldest = false },
 				{ "ignore-low-bugs=", "Ignore any bug references to bugs with IDs less than 1000 (Defaults to true)", (bool v) => options.IgnoreLowBugs = v },
 				{ "explain", "Explain why each commit is considered a bug", v => options.Explain = true },
+				{ "disable-bugzilla", "Disable bugzilla validation of bugs. May increase false positive bugs but drastically reduce time taken.", v => options.DisableBugzillaValidation = true },
 			};
 
 			try

--- a/src/EntryPoint.cs
+++ b/src/EntryPoint.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Mono.Options;
 using Optional;
+using Optional.Unsafe;
 
 namespace clio
 {
@@ -29,21 +30,18 @@ namespace clio
 				{ "b|list-bugs", "List bugs discovered instead of formatting release notes", v => requestedAction = ActionType.ListBugs },
 				{ "f|format-notes=", "Output formatted release notes of a given type (must be a built in template type)", v => {
 						if (!TemplateGenerator.ValidateTemplateName (v))
-						{
-							Console.Error.WriteLine ($"Unable to find template {v} embedded as a resource.");
-							Environment.Exit (-1);
-						}
+							Die ($"Unable to find template {v} embedded as a resource.");
 
 						options.Template = v.Some ();
 						requestedAction = ActionType.GenerateReleaseNotes;
 					}},
 
 				{ "o|output=", "Path to output release notes (Defaults to current directory)", o => options.OutputPath = o },
-				{ "s|starting=", "Starting to consider", s => options.Starting = s.Some () },
-				{ "e|ending=", "Ending to consider", e => options.Ending = e.Some () },
+				{ "oldest=", "Starting to consider", s => options.Oldest = s.Some () },
+				{ "newest=", "Ending to consider", e => options.Newest = e.Some () },
 
 				{ "single=", "Analyze just a single commit", e => options.SingleCommit = e.Some () },
-				{ "exclude-starting-item", "Exclude starting items from range considered (included by default)", v => options.IncludeStarting = false },
+				{ "exclude-oldest", "Exclude oldest item from range considered (included by default)", v => options.IncludeOldest = false },
 				{ "ignore-low-bugs=", "Ignore any bug references to bugs with IDs less than 1000 (Defaults to true)", (bool v) => options.IgnoreLowBugs = v },
 				{ "explain", "Explain why each commit is considered a bug", v => options.Explain = true },
 			};
@@ -63,8 +61,20 @@ namespace clio
 				Console.Error.WriteLine ("Could not parse the command line arguments: {0}", e.Message);
 			}
 
+			if (options.Oldest.HasValue && options.Newest.HasValue)
+			{
+				if (!CommitFinder.ValidateGitHashes (path, options.Oldest.ValueOrFailure (), options.Newest.ValueOrFailure ()))
+					Environment.Exit (-1);
+			}
+
 			var request = new clio (path, options);
 			request.Run (requestedAction);	
+		}
+
+		static void Die (string v)
+		{
+			Console.Error.WriteLine (v);
+			Environment.Exit (-1);
 		}
 
 		static void ShowHelp (OptionSet os)

--- a/src/SearchOptions.cs
+++ b/src/SearchOptions.cs
@@ -13,8 +13,8 @@ namespace clio
 		public bool Explain { get; set; } = false;
 		public Option<string> SingleCommit { get; set; } = Option.None<string> ();
 
-		public Option<string> Starting { get; set; } = Option.None<string> ();
-		public bool IncludeStarting { get; set; } = true;
-		public Option<string> Ending { get; set; } = Option.None<string> ();
+		public Option<string> Oldest { get; set; } = Option.None<string> ();
+		public bool IncludeOldest { get; set; } = true;
+		public Option<string> Newest { get; set; } = Option.None<string> ();
 	}
 }

--- a/src/SearchOptions.cs
+++ b/src/SearchOptions.cs
@@ -9,6 +9,8 @@ namespace clio
 		public string OutputPath { get; set; } = Path.Combine (System.Environment.CurrentDirectory, "ReleaseNotes.md");
 		public Option<string> Template { get; set; } = Option.None<string> ();
 
+		public bool DisableBugzillaValidation { get; set; } = false;
+
 		public bool IgnoreLowBugs { get; set; } = true;
 		public bool Explain { get; set; } = false;
 		public Option<string> SingleCommit { get; set; } = Option.None<string> ();

--- a/src/TODO.md
+++ b/src/TODO.md
@@ -1,5 +1,4 @@
 ﻿- Handle branches instead of hashes (walk up to commit parent?)
-
-- Be able to update existing?
-
 - Look at something for feature PRs?
+
+- Be able to update existing? (Handled for now by printing bug table)

--- a/src/TODO.md
+++ b/src/TODO.md
@@ -2,7 +2,4 @@
 
 - Be able to update existing?
 
-- Warn about inverted ranges
-
 - Look at something for feature PRs?
-- Option to disable bugzilla validation

--- a/src/TemplateGenerator.cs
+++ b/src/TemplateGenerator.cs
@@ -62,8 +62,12 @@ namespace clio
 			return builder.ToString ();
 		}
 
-		static string FormatBug (BugEntry bug, SearchOptions options)
+		public static string FormatBug (BugEntry bug, SearchOptions options)
 		{
+			// If bugzilla validation is disabled, all bugs are uncertain
+			if (string.IsNullOrEmpty (bug.Title))
+				return FormatUncertainBug (bug, options);
+
 			switch (options.Template.ValueOr (""))
 			{
 				case "Android":
@@ -75,7 +79,7 @@ namespace clio
 			}
 		}
 
-		static string FormatUncertainBug (BugEntry bug, SearchOptions options)
+		public static string FormatUncertainBug (BugEntry bug, SearchOptions options)
 		{
 			switch (options.Template.ValueOr (""))
 			{

--- a/src/TemplateGenerator.cs
+++ b/src/TemplateGenerator.cs
@@ -12,9 +12,9 @@ namespace clio
 		{
 			string template = GetTemplateText (options.Template.ValueOr (""));
 
-			template = template.Replace ("{START_RANGE}", options.Starting.ValueOr (""));
-			template = template.Replace ("{END_RANGE}", options.Ending.ValueOr (""));
-			template = template.Replace ("{INCLUDE_STARTING}", options.IncludeStarting ? "True" : "False");
+			template = template.Replace ("{OLDEST_COMMIT_CONSIDERED}", options.Oldest.ValueOr (""));
+			template = template.Replace ("{NEWEST_COMMIT_CONSIDERED}", options.Newest.ValueOr (""));
+			template = template.Replace ("{INCLUDE_OLDEST}", options.IncludeOldest ? "True" : "False");
 
 			template = template.Replace ("{BUG_LIST}", GetBugReportText (bugCollection, options));
 

--- a/src/Templates/Android.md
+++ b/src/Templates/Android.md
@@ -1,8 +1,8 @@
 ﻿id:XXX
 title:Xamarin.Android XXX
-clio-start-range:{START_RANGE}
-clio-end-range:{END_RANGE}
-clio-include-starting:{INCLUDE_STARTING}
+clio-start-range:{OLDEST_COMMIT_CONSIDERED}
+clio-end-range:{NEWEST_COMMIT_CONSIDERED}
+clio-include-starting:{INCLUDE_OLDEST}
 
 Xamarin.Android XXX: XXX
 

--- a/src/Templates/Mac.md
+++ b/src/Templates/Mac.md
@@ -2,9 +2,9 @@
 title:Xamarin.Mac
 version:XXX
 releasedate:XXX
-clio-start-range:{START_RANGE}
-clio-end-range:{END_RANGE}
-clio-include-starting:{INCLUDE_STARTING}
+clio-start-range:{OLDEST_COMMIT_CONSIDERED}
+clio-end-range:{NEWEST_COMMIT_CONSIDERED}
+clio-include-starting:{INCLUDE_OLDEST}
 
 Requirements
 ============

--- a/src/Templates/iOS.md
+++ b/src/Templates/iOS.md
@@ -2,9 +2,9 @@
 title:Xamarin.iOS
 version:XXX
 releasedate:XXX
-clio-start-range:{START_RANGE}
-clio-end-range:{END_RANGE}
-clio-include-starting:{INCLUDE_STARTING}
+clio-start-range:{OLDEST_COMMIT_CONSIDERED}
+clio-end-range:{NEWEST_COMMIT_CONSIDERED}
+clio-include-starting:{INCLUDE_OLDEST}
 
 Requirements
 ============

--- a/src/clio.cs
+++ b/src/clio.cs
@@ -45,7 +45,7 @@ namespace clio
 
 			if (action == ActionType.ListBugs)
 			{
-				PrintBugs (bugCollection);
+				PrintBugs (bugCollection, Options);
 				return;
 			}
 
@@ -58,15 +58,18 @@ namespace clio
 			throw new InvalidOperationException ($"Internal Error - Unknown action requested {action}");
 		}
 
-		void PrintBugs (BugCollection bugCollection)
+		void PrintBugs (BugCollection bugCollection, SearchOptions options)
 		{
 			Console.WriteLine ("Confirmed Bugs:");
 			foreach (var bug in bugCollection.ConfirmedBugs)
-				Console.WriteLine ($"[{bug.ID}] - {bug.Title}" + (String.IsNullOrEmpty (bug.SecondaryTitle) ? "" : $" / {bug.SecondaryTitle}"));
+				Console.WriteLine (TemplateGenerator.FormatBug (bug, options));
 
-			Console.WriteLine ("\nUncertain Bugs:");
-			foreach (var bug in bugCollection.UncertainBugs)
-				Console.WriteLine ($"[{bug.ID}] - {bug.SecondaryTitle}");
+			if (bugCollection.UncertainBugs.Count () > 0)
+			{
+				Console.WriteLine ("\nUncertain Bugs:");
+				foreach (var bug in bugCollection.UncertainBugs)
+					Console.WriteLine (TemplateGenerator.FormatUncertainBug (bug, options));
+			}
 		}
 
 		void PrintCommits (IEnumerable<CommitInfo> commits)

--- a/tests/BugCollector.cs
+++ b/tests/BugCollector.cs
@@ -14,7 +14,7 @@ namespace clio.Tests
 		public void BugCollector_HandlesDuplicateBugEntries ()
 		{
 			// One commit with certain, one without. Only one copy in final output
-			var options = new SearchOptions { Starting = "ad26139".Some (), Ending = "6c280ad".Some () };
+			var options = new SearchOptions { Oldest = "ad26139".Some (), Newest = "6c280ad".Some () };
 			var commits = CommitFinder.Parse (TestDataLocator.GetPath (), options);
 			var parsedCommits = CommitParser.Parse (commits, options).ToList ();
 
@@ -27,7 +27,7 @@ namespace clio.Tests
 		[Test]
 		public void BugCollector_SmokeTest ()
 		{
-			var options = new SearchOptions { Starting = "98fff31".Some (), Ending = "6c280ad".Some () };
+			var options = new SearchOptions { Oldest = "98fff31".Some (), Newest = "6c280ad".Some () };
 			var commits = CommitFinder.Parse (TestDataLocator.GetPath (), options);
 			var parsedCommits = CommitParser.Parse (commits, options).ToList ();
 

--- a/tests/CommitFinder.cs
+++ b/tests/CommitFinder.cs
@@ -17,7 +17,7 @@ namespace clio.Tests
 		[Test]
 		public void CommitFinder_ParseInvalidBranch_ReturnsEmpty ()
 		{
-			var commits = CommitFinder.Parse (TestDataLocator.GetPath (), new SearchOptions () { Starting = "a-non-existant-branch".Some () });
+			var commits = CommitFinder.Parse (TestDataLocator.GetPath (), new SearchOptions () { Oldest = "a-non-existant-branch".Some () });
 			Assert.Zero (commits.Count ());
 		}
 
@@ -53,12 +53,12 @@ namespace clio.Tests
 		public void CommitFinder_SubsetRange_ReturnsCorrectEntires ()
 		{
 			SearchOptions options = new SearchOptions ();
-			options.Starting = "4bb85fb".Some ();
-			options.Ending = "261dab6".Some ();
+			options.Oldest = "4bb85fb".Some ();
+			options.Newest = "261dab6".Some ();
 			var commits = CommitFinder.Parse (TestDataLocator.GetPath (), options);
 			Assert.AreEqual (6, commits.Count ());
 
-			options.IncludeStarting = false;
+			options.IncludeOldest = false;
 			commits = CommitFinder.Parse (TestDataLocator.GetPath (), options);
 			Assert.AreEqual (5, commits.Count ());
 		}
@@ -67,7 +67,7 @@ namespace clio.Tests
 		public void CommitFinder_EndingOnlyRange_ReturnsCorrectEntires ()
 		{
 			SearchOptions options = new SearchOptions ();
-			options.Ending = "261dab6".Some ();
+			options.Newest = "261dab6".Some ();
 			var commits = CommitFinder.Parse (TestDataLocator.GetPath (), options);
 			Assert.AreEqual (20, commits.Count ());
 		}
@@ -77,11 +77,11 @@ namespace clio.Tests
 		{
 			// This is brittle if we add more tests data
 			SearchOptions options = new SearchOptions ();
-			options.Starting = "261dab6".Some ();
+			options.Oldest = "261dab6".Some ();
 			var commits = CommitFinder.Parse (TestDataLocator.GetPath (), options);
 			Assert.AreEqual (5, commits.Count ());
 
-			options.IncludeStarting = false;
+			options.IncludeOldest = false;
 			commits = CommitFinder.Parse (TestDataLocator.GetPath (), options);
 			Assert.AreEqual (4, commits.Count ());
 		}


### PR DESCRIPTION
- Rename confusing starting/ending to oldest/newest
- Add hash validation to print nice errors instead of zero entries
- Add option to disable bugzilla validation
- Improve bug printing table to be pastable into release notes