### PR TITLE
Ability to list and ignore merge commits

### DIFF
--- a/src/EntryPoint.cs
+++ b/src/EntryPoint.cs
@@ -46,8 +46,9 @@ namespace clio
 			{
 				{ "h|?|help", "Displays the help", v => requestedAction = ActionType.Help },
 				{ "l|list-commits", "List commits that would be considered", v => requestedAction = ActionType.ListConsideredCommits },
-				{ "b|list-bugs", "List bugs discovered instead of formatting release notes", v => requestedAction = ActionType.ListBugs },
-				{ "x|export-bugs", "Export bugs discovered instead of formatting release notes", v => requestedAction = ActionType.ExportBugs },
+				{ "b|list-bugs", "List bugs discovered", v => requestedAction = ActionType.ListBugs },
+				{ "x|export-bugs", "Export bugs discovered", v => requestedAction = ActionType.ExportBugs },
+				{ "list-merge-commits", "Only list merge commits in requested range (to consider to filter)", v => requestedAction = ActionType.ListMergeCommits },
 				{ "output-file=", "Output file for export-bugs", v => outputFile = v },
 				{ "oldest=", "Starting hash to consider (hash range mode)", s => SetHashRange (s, null) },
 				{ "newest=", "Ending hash to consider (hash range mode)", e => SetHashRange (null, e) },
@@ -102,6 +103,7 @@ namespace clio
 				{ "collect-authors", "Generate a list of unique authors to commits listed", v => options.CollectAuthors = true},
 				{ "expected-target-milestone=", "Target Milestone to expect when validate-bug-status (instead of using the most common).", v => options.ExpectedTargetMilestone = v},
 				{ "ignore=", "Commit hashes to ignore", v => options.CommitsToIgnore.Add (v) },
+				{ "ignore-merge-commit=", "Commit hashes to ignore", v => options.MergeCommitsToIgnore.Add (v) },
 				new ResponseFileSource (),
 			};
 
@@ -132,6 +134,10 @@ namespace clio
 
 			if (requestedAction != ActionType.ExportBugs && !string.IsNullOrEmpty (outputFile))
 				Die ("--outputfile= can only be specified with --export-bugs.");
+
+			if (requestedAction != ActionType.ListMergeCommits && range == null)
+				Die ("--list-merge-commits requires hash range");
+
 
 			if (!RepositoryValidator.ValidateGitHashes (path, range))
 				Environment.Exit (-1);

--- a/src/SearchOptions.cs
+++ b/src/SearchOptions.cs
@@ -43,6 +43,7 @@ namespace clio
 		public bool ValidateBugStatus { get; set; } = false;
 		public bool CollectAuthors { get; set; } = false;
 		public List<string> CommitsToIgnore { get; set; } = new List<string> ();
+		public HashSet<string> MergeCommitsToIgnore { get; set; } = new HashSet<string> ();
 
 		public string ExpectedTargetMilestone { get; set; }
 	}

--- a/src/clio.cs
+++ b/src/clio.cs
@@ -14,6 +14,7 @@ namespace clio
 		Help,
 		ListConsideredCommits,
 		ListBugs,
+		ListMergeCommits,
 		ExportBugs
 	}
 
@@ -33,9 +34,16 @@ namespace clio
 
 		static async Task ProcessAsync (string path, SearchOptions options, ISearchRange range, ActionType action, string outputFile)
 		{
+			if (action == ActionType.ListMergeCommits) {
+				if (range is HashSearchRange hsr)
+					ConsolePrinter.PrintCommits (CommitFinder.FindMergeCommits (path, options, hsr));
+				Explain.Print ($"Only listing of merge commits was requested. Exiting.");
+				return;
+			}
+
 			IEnumerable<CommitInfo> commits;
 			if (range is HashSearchRange hashSearchRange)
-				commits = CommitFinder.ParseHashRange (path, options, hashSearchRange.Oldest, hashSearchRange.Newest);
+				commits = CommitFinder.ParseHashRange (path, options, hashSearchRange);
 			else if (range is BranchSearchRange branchSearchRange)
 				commits = CommitFinder.ParseBranchRange (path, options, branchSearchRange.Base, branchSearchRange.Branch);
 			else


### PR DESCRIPTION
- --list-merge-commits will list all merge commits in hash range
- --ignore-merge-commit will ExcludeReachableFrom those commits when looking for commits to consider